### PR TITLE
fix proposal for Sista bytecode

### DIFF
--- a/src/RoelTyper/PharoInstvarInterfaceExtractor.class.st
+++ b/src/RoelTyper/PharoInstvarInterfaceExtractor.class.st
@@ -105,6 +105,22 @@ PharoInstvarInterfaceExtractor >> pushConsArrayWithElements: anArray [
 ]
 
 { #category : #'instruction decoding' }
+PharoInstvarInterfaceExtractor >> pushFullClosure: compiledBlock numCopied: numCopied receiverOnStack: onStack ignoreOuterContext: ignore [
+
+	| blockSize numArgs | 
+	numArgs := compiledBlock numArgs.
+	blockSize := 3.
+	
+	self newBlockMapping.
+	self blocksArgsBySize add: blockSize + input pc - 1.
+	1 to: numArgs do: [:index | self blockMapping add: #blockArg->index.].
+	numCopied timesRepeat: [ self blockMapping add: stack removeLast afterIndex: numArgs]. 
+	stack addLast: #block.
+	blockArgs := numArgs.
+	
+]
+
+{ #category : #'instruction decoding' }
 PharoInstvarInterfaceExtractor >> pushNewArrayOfSize: numElements [ 
 	"Push New Array of size numElements bytecode."
 	stack addLast: #computed 


### PR DESCRIPTION
RoelTyper does not work in Pharo 9 and 10. This patch makes it work better but the test `InstvarInterfaceExtractorTest>>#testblockuwx` is still yellow. 

I'm not sure with the block size. This method is based on `PharoInstvarInterfaceExtractor>>#pushClosureCopyNumCopiedValues:numArgs:blockSize:`