### PR TITLE
More block fixes, switched to GH Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+## Adapted from:
+##    - Magritte - https://github.com/magritte-metamodel/magritte/blob/master/.github/workflows/runTests.yaml
+##    - OpenPonk - https://github.com/OpenPonk/ci-scripts/blob/master/.github/workflows/test-nightly.yml
+
+name: Tests
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        smalltalk: [ Pharo64-13, Pharo64-12, Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo64-6.1 ]
+    name: ${{ matrix.smalltalk }}
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2  
+      - name: Load SmalltalkCI Environment    
+        uses: hpi-swa/setup-smalltalkCI@1.3.4
+        with:
+          smalltalk-image: ${{ matrix.smalltalk }}
+      - name: Load Image and Run Tests
+        run: smalltalkci -s ${{ matrix.smalltalk }}
+        shell: bash
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 15

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,8 +1,17 @@
 SmalltalkCISpec {
   #loading : [
     SCIMetacelloLoadSpec {
+      #platforms : [
+        #pharo
+      ],
       #baseline : 'RoelTyper',
-      #directory : 'src'
+      #directory : 'src',
+      #load : [ 'Tests' ]
     }
-  ]
+  ],
+  #testing : {
+    #packages : [
+      'RoelTyper*'
+    ]
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: smalltalk
-sudo: false
-
-os:
-  - linux
-
-smalltalk:
-  - Pharo64-7.0

--- a/src/RoelTyper-Tests/ASampleClass.class.st
+++ b/src/RoelTyper-Tests/ASampleClass.class.st
@@ -50,6 +50,30 @@ ASampleClass >> c [
 	c := b
 ]
 
+{ #category : 'blocks typing' }
+ASampleClass >> inlinedBlocks [
+
+	| t1 t2 t3 |
+	t1 := 1.
+	t2 ifNotNil: [ :t4 |
+		| t5 t6 |
+		t5 := 't5'.
+		t6 := 1.2.
+		t4 > 5.
+		Array new do: [ :t7 |
+			| t8 |
+			t7 asInteger.
+			t7 ifNil: [ t8 asString ].
+			Array new withIndexDo: [ :t9 :t10 |
+				| t11 t12 |
+				t11 := $1.
+				t12 := #t12.
+				t6 * t6.
+				t9 , t10 ] ] ].
+	t3 := #(  ).
+	^ Set new
+]
+
 { #category : 'temporaries typing' }
 ASampleClass >> nestedBlocksComplex: mArg [
 
@@ -83,16 +107,18 @@ ASampleClass >> nestedBlocksComplex: mArg [
 { #category : 'blocks typing' }
 ASampleClass >> nestedBlocksUsingOuterTemps [
 
-	| t1 tb1 |
-	tb1 := [
-	       | t2 tb2 |
-	       tb2 := [
-	              | t3 |
-	              t3 := 1.
-	              t1 := 1.0.
-	              t2 := '2' ].
-	       tb2 value ].
-	tb1 value
+	| ta1 ta2 ta3 ta4 |
+	ta2 := 'ta2'.
+	ta4 := [
+	       | tb1 tb2 tb3 tb4 |
+	       tb4 := Date today.
+	       tb1 := [
+	              | tc1 |
+	              tc1 := 1.
+	              ta3 := 1.0.
+	              tb3 := $2 ].
+	       tb1 value ].
+	ta4 value
 ]
 
 { #category : 'blocks typing' }

--- a/src/RoelTyper-Tests/InstvarInterfaceExtractorTest.class.st
+++ b/src/RoelTyper-Tests/InstvarInterfaceExtractorTest.class.st
@@ -370,31 +370,31 @@ InstvarInterfaceExtractorTest >> testInlinedBlocks [
 		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block2->t8') interface
-		includesAll: { #asString }.
+		hasSameElements: { #asString }.
 	self
 		assertCollection: (results at: #'_block4->t9') assignments
 		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t9') interface
-		includesAll: { #, }.
+		hasSameElements: { #, }.
 	self
 		assertCollection: (results at: #'_block4->t10') assignments
 		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t10') interface
-		includesAll: {  }.
+		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t11') assignments
 		hasSameElements: { Character }.
 	self
 		assertCollection: (results at: #'_block4->t11') interface
-		includesAll: {  }.
+		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t12') assignments
 		hasSameElements: { ByteSymbol }.
 	self
 		assertCollection: (results at: #'_block4->t12') interface
-		includesAll: {  }
+		hasSameElements: {  }
 ]
 
 { #category : 'tests - assignments' }

--- a/src/RoelTyper-Tests/InstvarInterfaceExtractorTest.class.st
+++ b/src/RoelTyper-Tests/InstvarInterfaceExtractorTest.class.st
@@ -309,6 +309,94 @@ InstvarInterfaceExtractorTest >> testIndirectAssignments [
 	(TypeCollector typeInstvar: #c ofClass: ASampleClass) types
 ]
 
+{ #category : 'tests - message sends' }
+InstvarInterfaceExtractorTest >> testInlinedBlocks [
+
+	| collector results |
+	collector := TypeCollector new.
+	results := collector
+		           typeTmpsIn: ASampleClass >> #inlinedBlocks
+		           ofClass: ASampleClass.
+	self
+		assertCollection: results keys
+		hasSameElements:
+			#( #'^' #t1 #t2 #t3 #'_block1->t4' #'_block1->t5' #'_block1->t6'
+			   #'_block2->t7' #'_block2->t8' #'_block4->t9' #'_block4->t10'
+			   #'_block4->t11' #'_block4->t12' ).
+	self
+		assertCollection: (results at: #'^') assignments
+		hasSameElements: { Set }.
+	self
+		assertCollection: (results at: #t1) assignments
+		hasSameElements: { SmallInteger }.
+	self
+		assertCollection: (results at: #t1) interface
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #t2) assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #t3) assignments
+		hasSameElements: { Array }.
+	self
+		assertCollection: (results at: #t3) interface
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block1->t4') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block1->t4') interface
+		hasSameElements: { #> }.
+	self
+		assertCollection: (results at: #'_block1->t5') assignments
+		hasSameElements: { ByteString }.
+	self
+		assertCollection: (results at: #'_block1->t5') interface
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block1->t6') assignments
+		hasSameElements: { SmallFloat64 }.
+	self
+		assertCollection: (results at: #'_block1->t6') interface
+		hasSameElements: { #* }.
+	self
+		assertCollection: (results at: #'_block2->t7') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block2->t7') interface
+		includesAll: { #asInteger }.
+	self
+		assertCollection: (results at: #'_block2->t8') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block2->t8') interface
+		includesAll: { #asString }.
+	self
+		assertCollection: (results at: #'_block4->t9') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block4->t9') interface
+		includesAll: { #, }.
+	self
+		assertCollection: (results at: #'_block4->t10') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block4->t10') interface
+		includesAll: {  }.
+	self
+		assertCollection: (results at: #'_block4->t11') assignments
+		hasSameElements: { Character }.
+	self
+		assertCollection: (results at: #'_block4->t11') interface
+		includesAll: {  }.
+	self
+		assertCollection: (results at: #'_block4->t12') assignments
+		hasSameElements: { ByteSymbol }.
+	self
+		assertCollection: (results at: #'_block4->t12') interface
+		includesAll: {  }
+]
+
 { #category : 'tests - assignments' }
 InstvarInterfaceExtractorTest >> testInstanceAssignment [
 	| collector |
@@ -474,18 +562,31 @@ InstvarInterfaceExtractorTest >> testNestedBlocksUsingOuterTemps [
 	self
 		assertCollection: results keys
 		hasSameElements:
-		#( #'^' #t1 #tb1 #'_block1->t2' #'_block1->tb2' #'_block2->t3' ).
+			#( #'^' #ta1 #ta2 #ta3 #ta4 #'_block1->tb1' #'_block1->tb2'
+			   #'_block1->tb3' #'_block1->tb4' #'_block2->tc1' ).
 	self
 		assertCollection: (results at: #'^') assignments
 		hasSameElements: { ASampleClass }.
 	self
-		assertCollection: (results at: #t1) assignments
-		hasSameElements: { SmallFloat64 }.
-	self
-		assertCollection: (results at: #'_block1->t2') assignments
+		assertCollection: (results at: #ta2) assignments
 		hasSameElements: { ByteString }.
 	self
-		assertCollection: (results at: #'_block2->t3') assignments
+		assertCollection: (results at: #ta3) assignments
+		hasSameElements: { SmallFloat64 }.
+	self
+		assertCollection: (results at: #ta4) assignments
+		hasSameElements: { BlockClosure }.
+	self
+		assertCollection: (results at: #'_block1->tb1') assignments
+		hasSameElements: { BlockClosure }.
+	self
+		assertCollection: (results at: #'_block1->tb3') assignments
+		hasSameElements: { Character }.
+	self
+		assertCollection: (results at: #'_block1->tb4') assignments
+		hasSameElements: { Date }.
+	self
+		assertCollection: (results at: #'_block2->tc1') assignments
 		hasSameElements: { SmallInteger }
 ]
 

--- a/src/RoelTyper-Tests/ManifestRoelTyperTests.class.st
+++ b/src/RoelTyper-Tests/ManifestRoelTyperTests.class.st
@@ -10,20 +10,29 @@ Class {
 }
 
 { #category : 'code-critics' }
-ManifestRoelTyperTests class >> ruleFloatReferencesRuleV1FalsePositive [
+ManifestRoelTyperTests class >> ruleEqualNotUsedRuleV1FalsePositive [
 
 	<ignoreForCoverage>
-	^ #(#(#(#RGPackageDefinition #(#'RoelTyper-Tests')) #'2024-09-05T13:06:47.83+02:00') )
+	^ #(#(#(#RGClassDefinition #(#ASampleClass)) #'2025-03-24T15:22:36.333+01:00') )
 ]
 
 { #category : 'code-critics' }
-ManifestRoelTyperTests class >> ruleGRTemporaryNeitherReadNorWrittenRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#TypeCollectorTest #methodWithTmpInBlock: #false)) #'2018-11-15T18:15:36.392243+01:00') )
+ManifestRoelTyperTests class >> ruleModifiesCollectionRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGClassDefinition #(#ASampleClass)) #'2025-03-24T15:22:44.782+01:00') )
 ]
 
 { #category : 'code-critics' }
-ManifestRoelTyperTests class >> ruleRefersToClassRuleV1FalsePositive [
+ManifestRoelTyperTests class >> ruleStringConcatenationRuleV1FalsePositive [
 
 	<ignoreForCoverage>
-	^ #(#(#(#RGMethodDefinition #(#InstvarInterfaceExtractorTest #mainTestClass #false)) #'2024-09-05T21:27:56.841+02:00') )
+	^ #(#(#(#RGClassDefinition #(#ASampleClass)) #'2025-03-24T15:22:40.969+01:00') )
+]
+
+{ #category : 'code-critics' }
+ManifestRoelTyperTests class >> ruleTempsReadBeforeWrittenRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGClassDefinition #(#ASampleClass)) #'2025-03-24T15:22:31.017+01:00') )
 ]

--- a/src/RoelTyper/ExtractedType.class.st
+++ b/src/RoelTyper/ExtractedType.class.st
@@ -50,6 +50,7 @@ ExtractedType >> addReverseLinkedExtractedType: anExtractedType [
 
 { #category : 'private-accessing' }
 ExtractedType >> addSend: anObject [
+
 	self interface add: anObject
 ]
 
@@ -98,17 +99,20 @@ ExtractedType >> flattenLinks [
 { #category : 'private' }
 ExtractedType >> foldInterfaceTypes: interfaceClasses withAssignmentTypes: assignmentClasses [
 
-	| tmp | 
-	assignmentClasses remove: UndefinedObject ifAbsent: [].
-	tmp:=interfaceClasses.
+	| tmp |
+	assignmentClasses remove: UndefinedObject ifAbsent: [  ].
+	tmp := interfaceClasses.
 	(assignmentClasses isEmpty and: [
-		((interface includes: #value) 
-		or: [interface includes: #value:]) and: [interfaceClasses includes: BlockClosure]]) 
-			ifTrue: [ tmp:=OrderedCollection with: BlockClosure]
-			ifFalse: [ tmp:=interfaceClasses].
-	^self class mergerClass
-		interfaceTypes: tmp
-		assignmentTypes: assignmentClasses
+		 ((interface includes: #value) or: [
+			  (interface includes: #value:) or: [ interface includes: #cull: ] ])
+			 and: [ interfaceClasses includes: BlockClosure ] ]) ifTrue: [
+		tmp := OrderedCollection streamContents: [ :s |
+			       s nextPut: BlockClosure.
+			       (interfaceClasses includes: Symbol) ifTrue: [
+				       s nextPut: Symbol ] ] ].
+	^ self class mergerClass
+		  interfaceTypes: tmp
+		  assignmentTypes: assignmentClasses
 ]
 
 { #category : 'testing' }

--- a/src/RoelTyper/InstvarInterfaceExtractor.class.st
+++ b/src/RoelTyper/InstvarInterfaceExtractor.class.st
@@ -190,7 +190,8 @@ InstvarInterfaceExtractor >> nativeSend: selector numArgs: na [
 
 { #category : 'opcodes-data movement' }
 InstvarInterfaceExtractor >> pop [
-	stack removeLast
+
+	^ stack removeLast
 ]
 
 { #category : 'instruction decoding' }

--- a/src/RoelTyper/PharoAbstractInstvarInterfaceExtractor.class.st
+++ b/src/RoelTyper/PharoAbstractInstvarInterfaceExtractor.class.st
@@ -34,18 +34,18 @@ PharoAbstractInstvarInterfaceExtractor class >> forEncoder: aBytecodeEncoder [
 	^ (self classForEncoder: aBytecodeEncoder) new
 ]
 
-{ #category : 'block' }
+{ #category : 'blocks' }
 PharoAbstractInstvarInterfaceExtractor >> blockMapping [
 	^ blockTempsMapping last
 ]
 
-{ #category : 'instruction decoding' }
+{ #category : 'blocks' }
 PharoAbstractInstvarInterfaceExtractor >> blockMappingNotFoundFor: offset [
 
 	^ self error: 'Could not find temp at offset ' , offset asString
 ]
 
-{ #category : 'block' }
+{ #category : 'blocks' }
 PharoAbstractInstvarInterfaceExtractor >> blocksDecrement [
 	"do nothing"
 
@@ -76,7 +76,7 @@ PharoAbstractInstvarInterfaceExtractor >> extractInterfacesFrom: m addTo: aTypeC
 		self blocksDecrement ]
 ]
 
-{ #category : 'block' }
+{ #category : 'blocks' }
 PharoAbstractInstvarInterfaceExtractor >> inABlock [
 	^ blockTempsMapping isNotEmpty
 ]
@@ -100,7 +100,7 @@ PharoAbstractInstvarInterfaceExtractor >> methodReturnTop [
 	^self pop
 ]
 
-{ #category : 'block' }
+{ #category : 'blocks' }
 PharoAbstractInstvarInterfaceExtractor >> newBlockMapping [
 	blockTempsMapping add: OrderedCollection new.
 	
@@ -145,16 +145,13 @@ PharoAbstractInstvarInterfaceExtractor >> pushRemoteTemp: remoteTempIndex inVect
 	"Pharo 9+
 	 Push Contents at Offset in Temp Vector bytecode."
 
-	self inABlock
-		ifTrue: [ stack add: (self blockMapping at: tempVectorIndex + 1) ]
-		ifFalse: [ stack add: #temp -> tempVectorIndex ]
+	stack add: #computed
 ]
 
 { #category : 'instruction decoding' }
 PharoAbstractInstvarInterfaceExtractor >> pushTemporaryVariable: offset [
 	"Push Contents Of Temporary Variable Whose Index Is the 
 	argument, offset, On Top Of Stack bytecode."
-
 	self inABlock
 		ifTrue: [
 			stack add: (self blockMapping
@@ -163,7 +160,7 @@ PharoAbstractInstvarInterfaceExtractor >> pushTemporaryVariable: offset [
 		ifFalse: [ stack add: #temp -> offset ]
 ]
 
-{ #category : 'removing' }
+{ #category : 'blocks' }
 PharoAbstractInstvarInterfaceExtractor >> removeBlockMapping [
 	blockTempsMapping removeLast
 ]

--- a/src/RoelTyper/PharoEncoderSistaV1InstvarInterfaceExtractor.class.st
+++ b/src/RoelTyper/PharoEncoderSistaV1InstvarInterfaceExtractor.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'PharoEncoderSistaV1InstvarInterfaceExtractor',
 	#superclass : 'PharoAbstractInstvarInterfaceExtractor',
 	#instVars : [
-		'tempVarAmount'
+		'tempVarAmount',
+		'preparedVectorSize'
 	],
 	#category : 'RoelTyper-Pharo',
 	#package : 'RoelTyper',
@@ -13,7 +14,16 @@ Class {
 PharoEncoderSistaV1InstvarInterfaceExtractor >> extractInterfacesFrom: m addTo: aTypeCollector [
 
 	tempVarAmount := m numTemps.
+	preparedVectorSize := 0.
 	^ super extractInterfacesFrom: m addTo: aTypeCollector
+]
+
+{ #category : 'instruction decoding' }
+PharoEncoderSistaV1InstvarInterfaceExtractor >> indexOfVectorTemp: remoteTempIndex inVectorAt: tempVectorIndex [
+
+	| methodLevelOffset |
+	methodLevelOffset := self tempOffsetFrom: tempVectorIndex.
+	^ methodLevelOffset + remoteTempIndex
 ]
 
 { #category : 'instruction decoding' }
@@ -27,12 +37,21 @@ PharoEncoderSistaV1InstvarInterfaceExtractor >> methodReturnTop [
 PharoEncoderSistaV1InstvarInterfaceExtractor >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Remove Top Of Stack And Store Into Offset of Temp Vector bytecode."
 
-	| methodLevelOffset rvalue |
-	rvalue := super
-		          popIntoRemoteTemp: remoteTempIndex
-		          inVectorAt: tempVectorIndex.
-	methodLevelOffset := self tempOffsetFrom: tempVectorIndex.
-	collector handleAssignment: rvalue forTmp: methodLevelOffset
+	| rvalue |
+	rvalue := stack removeLast.
+	collector
+		handleAssignment: rvalue
+		forTmp:
+		(self indexOfVectorTemp: remoteTempIndex inVectorAt: tempVectorIndex)
+]
+
+{ #category : 'instruction decoding' }
+PharoEncoderSistaV1InstvarInterfaceExtractor >> popIntoTemporaryVariable: offset [
+
+	preparedVectorSize isZero ifFalse: [
+		preparedVectorSize := 0.
+		^ self ].
+	^ super popIntoTemporaryVariable: offset
 ]
 
 { #category : 'instruction decoding' }
@@ -61,13 +80,27 @@ PharoEncoderSistaV1InstvarInterfaceExtractor >> pushFullClosure: compiledBlock n
 ]
 
 { #category : 'instruction decoding' }
+PharoEncoderSistaV1InstvarInterfaceExtractor >> pushNewArrayOfSize: aSize [
+
+	preparedVectorSize := aSize
+]
+
+{ #category : 'instruction decoding' }
+PharoEncoderSistaV1InstvarInterfaceExtractor >> pushRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
+
+	stack add: #temp -> (self indexOfVectorTemp: remoteTempIndex inVectorAt: tempVectorIndex)
+]
+
+{ #category : 'instruction decoding' }
 PharoEncoderSistaV1InstvarInterfaceExtractor >> storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Pharo 9+
 	 Store Top Of Stack And Store Into Offset of Temp Vector bytecode."
 
-	| methodLevelOffset rvalue |
-	methodLevelOffset := self tempOffsetFrom: tempVectorIndex.
+	| rvalue |
 	rvalue := stack removeLast.
-	collector handleAssignment: rvalue forTmp: methodLevelOffset.
+	collector
+		handleAssignment: rvalue
+		forTmp:
+		(self indexOfVectorTemp: remoteTempIndex inVectorAt: tempVectorIndex).
 	stack add: rvalue
 ]

--- a/src/RoelTyper/PharoEncoderSistaV1InstvarInterfaceExtractor.class.st
+++ b/src/RoelTyper/PharoEncoderSistaV1InstvarInterfaceExtractor.class.st
@@ -17,6 +17,13 @@ PharoEncoderSistaV1InstvarInterfaceExtractor >> extractInterfacesFrom: m addTo: 
 ]
 
 { #category : 'instruction decoding' }
+PharoEncoderSistaV1InstvarInterfaceExtractor >> methodReturnTop [
+	"Return Top Of Stack bytecode."
+
+	collector addAssignmentForReturn: self pop
+]
+
+{ #category : 'instruction decoding' }
 PharoEncoderSistaV1InstvarInterfaceExtractor >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Remove Top Of Stack And Store Into Offset of Temp Vector bytecode."
 

--- a/src/RoelTyper/PharoEncoderV3InstvarInterfaceExtractor.class.st
+++ b/src/RoelTyper/PharoEncoderV3InstvarInterfaceExtractor.class.st
@@ -9,18 +9,18 @@ Class {
 	#tag : 'Pharo'
 }
 
-{ #category : 'instruction decoding' }
+{ #category : 'blocks' }
 PharoEncoderV3InstvarInterfaceExtractor >> blockMappingNotFoundFor: offset [
 
 	^ #blockTemp -> (offset - self blockMapping size)
 ]
 
-{ #category : 'block' }
+{ #category : 'blocks' }
 PharoEncoderV3InstvarInterfaceExtractor >> blocksArgsBySize [
 	^ blocksLimits ifNil: [ blocksLimits := OrderedCollection new ]
 ]
 
-{ #category : 'block' }
+{ #category : 'blocks' }
 PharoEncoderV3InstvarInterfaceExtractor >> blocksDecrement [
 
 	blocksLimits := blocksLimits select: [ :e |

--- a/src/RoelTyper/TypeCollector.class.st
+++ b/src/RoelTyper/TypeCollector.class.st
@@ -140,37 +140,47 @@ TypeCollector >> addAssignment: val toReturnOf: aSelector [
 ]
 
 { #category : 'adding' }
-TypeCollector >> addAssignment: value toTmp: index [ 
-	((localTypingResults at: currentExtractedMethod) at: index + 1) addAssignment: value
+TypeCollector >> addAssignment: value toTmp: index [
+
+	^ self addAssignment: value toTmp: index in: currentExtractedMethod
 ]
 
 { #category : 'adding' }
 TypeCollector >> addAssignment: value toTmp: index in: aCompiledMethod [
-	((localTypingResults at: aCompiledMethod) at: index + 1) addAssignment: value
+
+	(self localTypingResultOf: aCompiledMethod index: index)
+		addAssignment: value
 ]
 
 { #category : 'adding' }
-TypeCollector >> addAssignmentForReturn: val [ 
+TypeCollector >> addAssignmentForReturn: val [
+
 	| eT |
 	eT := self extractedTypeForReturnInMethod: currentExtractedMethod.
-	val isInteger 
-		ifTrue: 
-			[ self 
+	val isInteger
+		ifTrue: [
+			self
 				withTranslatedIndex: val
-				do: [ :idx | eT addReverseLinkedExtractedType: (typingResults at: idx) ] ]
-		ifFalse: 
-			[ (val isVariableBinding and: [ val key = #temp ]) 
-				ifTrue: 
-					[ eT addReverseLinkedExtractedType: ((localTypingResults at: currentExtractedMethod) at: val value + 1) ]
-				ifFalse: 
-					[ (val isVariableBinding and: [ val key = #return ]) 
-						ifTrue: 
-							[ eT addReverseLinkedExtractedType: (self extractedTypeForReturnInMethod: theClass >> val value) ]
-						ifFalse: 
-							[  (val isVariableBinding and: [ val key = #blockArg ])
-							ifTrue: [
-							]
-						ifFalse: [(self assignmentTypeOf: val) ifNotNil: [ :result | eT addAssignment: result ] ] ] ]]
+				do: [ :idx |
+				eT addReverseLinkedExtractedType: (typingResults at: idx) ] ]
+		ifFalse: [
+			(val isVariableBinding and: [ val key = #temp ])
+				ifTrue: [
+					eT addReverseLinkedExtractedType:
+						(self
+							 localTypingResultOf: currentExtractedMethod
+							 index: val value) ]
+				ifFalse: [
+					(val isVariableBinding and: [ val key = #return ])
+						ifTrue: [
+							eT addReverseLinkedExtractedType:
+								(self extractedTypeForReturnInMethod: theClass >> val value) ]
+						ifFalse: [
+							(val isVariableBinding and: [ val key = #blockArg ])
+								ifTrue: [  ]
+								ifFalse: [
+									(self assignmentTypeOf: val) ifNotNil: [ :result |
+										eT addAssignment: result ] ] ] ] ]
 ]
 
 { #category : 'adding' }
@@ -208,9 +218,12 @@ TypeCollector >> addSend: selector to: index [
 ]
 
 { #category : 'adding' }
-TypeCollector >> addSend: selector toTmp: index [ 
+TypeCollector >> addSend: selector toTmp: index [
 	"Add a range check to filter out sends to instvars defined in superclasses, etc."
-	((localTypingResults at: currentExtractedMethod ) at: index + 1) addSend: selector
+
+	self haltIf: [ currentExtractedMethod = #runOnDAPackageRelationGraph: ].
+	(self localTypingResultOf: currentExtractedMethod index: index)
+		addSend: selector
 ]
 
 { #category : 'accessing' }
@@ -271,86 +284,72 @@ TypeCollector >> extractedTypeForReturnInMethod: aCompiledMethod [
 ]
 
 { #category : 'heuristics' }
-TypeCollector >> handleAssignment: val for: index [ 
-	val isInteger 
-		ifTrue: 
-			[ self 
-				withTranslatedIndex: val
-				do: 
-					[ :idx | 
-					(typingResults at: index + 1) addReverseLinkedExtractedType: (typingResults at: idx) ] ]
-		ifFalse: 
-			[ (val isVariableBinding and: [ val key = #temp ]) 
-				ifTrue: 
-					[ (typingResults at: index + 1) addReverseLinkedExtractedType: ((localTypingResults at: currentExtractedMethod) at: val value + 1) ]
-				ifFalse: 
-					[ (val isVariableBinding and: [ val key = #return ]) 
-						ifTrue: 
-							[ (typingResults at: index + 1) addReverseLinkedExtractedType: (self extractedTypeForReturnInMethod: theClass >> val value) ]
-						ifFalse: 
-							[ (val isVariableBinding and: [ val key = #blockArg ]) 
-							ifFalse: [(self assignmentTypeOf: val) ifNotNil: 
-								[ :result | 
-								self 
-									addAssignment: result
-									to: index ] ] ] ]]
+TypeCollector >> handleAssignment: val for: index [
+
+	val isInteger
+		ifTrue: [
+			self withTranslatedIndex: val do: [ :idx |
+				(typingResults at: index + 1) addReverseLinkedExtractedType:
+					(typingResults at: idx) ] ]
+		ifFalse: [
+			(val isVariableBinding and: [ val key = #temp ])
+				ifTrue: [
+					(typingResults at: index + 1) addReverseLinkedExtractedType:
+						(self
+							 localTypingResultOf: currentExtractedMethod
+							 index: val value) ]
+				ifFalse: [
+					(val isVariableBinding and: [ val key = #return ])
+						ifTrue: [
+							(typingResults at: index + 1) addReverseLinkedExtractedType:
+								(self extractedTypeForReturnInMethod: theClass >> val value) ]
+						ifFalse: [
+							(val isVariableBinding and: [ val key = #blockArg ]) ifFalse: [
+								(self assignmentTypeOf: val) ifNotNil: [ :result |
+									self addAssignment: result to: index ] ] ] ] ]
 ]
 
 { #category : 'heuristics' }
 TypeCollector >> handleAssignment: val forTmp: index [
 
-	val isInteger
-		ifTrue: [
-			self withTranslatedIndex: val do: [ :idx |
-				((localTypingResults at: currentExtractedMethod) at: index + 1)
-					addReverseLinkedExtractedType: (typingResults at: idx) ] ]
-		ifFalse: [
-			(val isVariableBinding and: [ val key = #temp ])
-				ifTrue: [
-					((localTypingResults at: currentExtractedMethod) at: index + 1)
-						addReverseLinkedExtractedType:
-						((localTypingResults at: currentExtractedMethod) at:
-							 val value + 1) ]
-				ifFalse: [
-					(val isVariableBinding and: [ val key = #return ])
-						ifTrue: [
-							((localTypingResults at: currentExtractedMethod) at: index + 1)
-								addReverseLinkedExtractedType:
-								(self extractedTypeForReturnInMethod: theClass >> val value) ]
-						ifFalse: [
-							(val isVariableBinding and: [ val key = #blockArg ]) ifFalse: [
-								(self assignmentTypeOf: val) ifNotNil: [ :result |
-									self addAssignment: result toTmp: index ] ] ] ] ]
+	^ self handleAssignment: val forTmp: index in: currentExtractedMethod
 ]
 
 { #category : 'heuristics' }
 TypeCollector >> handleAssignment: val forTmp: index in: aCompiledMethod [
 	"Cannot use ifNotNil: with argument in Squeak, so use a temporary instead."
-	val isInteger 
-		ifTrue: 
-			[ self 
-				withTranslatedIndex: val
-				do: 
-					[ :idx | 
-					((localTypingResults at: aCompiledMethod) at: index + 1) addReverseLinkedExtractedType: (typingResults at: idx).
-					 ] ]
-		ifFalse: 
-			[ (val isVariableBinding and: [ val key = #temp ]) 
-				ifTrue: 
-					[ ((localTypingResults at: aCompiledMethod ) at: index + 1) addReverseLinkedExtractedType: ((localTypingResults at: currentExtractedMethod) at: val value + 1).
-					 ]
-				ifFalse: 
-					[ (val isVariableBinding and: [ val key = #return ]) 
-						ifTrue: 
-							[ ((localTypingResults at: aCompiledMethod ) at: index + 1) addReverseLinkedExtractedType: (self extractedTypeForReturnInMethod: theClass >> val value) ]
+
+	val isInteger
+		ifTrue: [
+			self withTranslatedIndex: val do: [ :idx |
+				(self localTypingResultOf: aCompiledMethod index: index)
+					addReverseLinkedExtractedType: (typingResults at: idx) ] ]
+		ifFalse: [
+			(val isVariableBinding and: [ val key = #temp ])
+				ifTrue: [
+					(self localTypingResultOf: aCompiledMethod index: index)
+						addReverseLinkedExtractedType:
+						(self
+							 localTypingResultOf: currentExtractedMethod
+							 index: val value) ]
+				ifFalse: [
+					(val isVariableBinding and: [ val key = #return ])
+						ifTrue: [
+							(self localTypingResultOf: aCompiledMethod index: index)
+								addReverseLinkedExtractedType:
+								(self extractedTypeForReturnInMethod: theClass >> val value) ]
 						ifFalse: [
-							 (val isVariableBinding and: [ val key = #blockArg ]) 
-							ifFalse: [(self assignmentTypeOf: val) ifNotNil: 
-						[ :result | 
-						self 
-							addAssignment: result
-							toTmp: index
-							in: aCompiledMethod ] ] ]]]
+							(val isVariableBinding and: [ val key = #blockArg ]) ifFalse: [
+								(self assignmentTypeOf: val) ifNotNil: [ :result |
+									self addAssignment: result toTmp: index in: aCompiledMethod ] ] ] ] ]
+]
+
+{ #category : 'private' }
+TypeCollector >> indexInListForMethod: aCompiledMethod index: index [
+
+	index < 0 ifTrue: [
+		^ aCompiledMethod ast scope tempVarNames size - index ].
+	^ index + 1
 ]
 
 { #category : 'heuristics' }
@@ -359,21 +358,10 @@ TypeCollector >> languageSpecificPushSendOf: selector to: rec args: args [
 ]
 
 { #category : 'private' }
-TypeCollector >> lastAssignmentForIndex: anIndex [
-	| assignments |
-	assignments := (self typingResults at: anIndex) assignments.
-	^assignments isEmpty
-		ifTrue: [nil]
-		ifFalse: [assignments last]
-]
+TypeCollector >> localTypingResultOf: aMethod index: index [
 
-{ #category : 'private' }
-TypeCollector >> lastAssignmentForTmpIndex: anIndex [ 
-	| assignments |
-	assignments := ((localTypingResults at: currentExtractedMethod) at: anIndex) assignments.
-	^ assignments isEmpty 
-		ifTrue: [ nil ]
-		ifFalse: [ assignments last ]
+	^ (localTypingResults at: aMethod) at:
+		  (self indexInListForMethod: aMethod index: index)
 ]
 
 { #category : 'private' }
@@ -422,7 +410,6 @@ TypeCollector >> packagedResultsForCompiledMethod: aCompiledMethod [
 	arr := localTypingResults at: aCompiledMethod.
 
 	i := 0.
-
 	aCompiledMethod sourceNode allOwnTempNamesByOwners withIndexDo: [
 		:ownerWithListOfVarNames
 		:methodOrBlockIndex |
@@ -491,23 +478,29 @@ TypeCollector >> theClass [
 ]
 
 { #category : 'adding' }
-TypeCollector >> transformAsBlockArg: anExtractedTypeForTmp [ 
-	(localTypingResults at: anExtractedTypeForTmp compiledMethod) 
+TypeCollector >> transformAsBlockArg: anExtractedTypeForTmp [
+
+	(localTypingResults at: anExtractedTypeForTmp compiledMethod)
 		at: anExtractedTypeForTmp tempOffset
-		put: (ExtractedTypeForBlockArg 
-				forOffset: anExtractedTypeForTmp tempOffset
-				ofCompiledMethod: anExtractedTypeForTmp compiledMethod
-				inClass: anExtractedTypeForTmp ivarClass)
+		put: (ExtractedTypeForBlockArg
+				 forOffset: anExtractedTypeForTmp tempOffset
+				 ofCompiledMethod: anExtractedTypeForTmp compiledMethod
+				 inClass: anExtractedTypeForTmp ivarClass)
 ]
 
 { #category : 'adding' }
-TypeCollector >> transformAsBlockArgTheTmpOffset: offset [ 
-	((localTypingResults at: currentExtractedMethod ) at: (offset + 1)) asBlockArgInTypeCollector: self
+TypeCollector >> transformAsBlockArgTheTmpOffset: offset [
+
+	^ self
+		  transformAsBlockArgTheTmpOffset: offset
+		  in: currentExtractedMethod
 ]
 
 { #category : 'adding' }
-TypeCollector >> transformAsBlockArgTheTmpOffset: offset in: aCompiledMethod [ 
-	((localTypingResults at: aCompiledMethod ) at: (offset + 1)) asBlockArgInTypeCollector: self
+TypeCollector >> transformAsBlockArgTheTmpOffset: offset in: aCompiledMethod [
+
+	(self localTypingResultOf: aCompiledMethod index: offset)
+		asBlockArgInTypeCollector: self
 ]
 
 { #category : 'private' }

--- a/src/RoelTyper/TypeCollector.class.st
+++ b/src/RoelTyper/TypeCollector.class.st
@@ -391,7 +391,7 @@ TypeCollector >> onClass: aClass [
 	typingResults := (instVars collect: [ :ivar |
 		                  ExtractedType forInstvar: ivar inClass: aClass ])
 		                 asArray.
-	localTypingResults := IdentityDictionary new.
+	localTypingResults := Dictionary new.
 	theClass selectorsAndMethodsDo: [ :sel :cm |
 		self addLocalTypingResultsFor: cm ]
 ]

--- a/src/RoelTyper_Pharo13/OCBlockNode.extension.st
+++ b/src/RoelTyper_Pharo13/OCBlockNode.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'ASTBlockNode' }
+Extension { #name : 'OCBlockNode' }
 
 { #category : '*RoelTyper_Pharo13' }
-ASTBlockNode >> ownTempNames [
+OCBlockNode >> ownTempNames [
 
 	^ PharoTypeCollector ownTempNamesForBlockNode: self
 ]

--- a/src/RoelTyper_Pharo13/OCMethodNode.extension.st
+++ b/src/RoelTyper_Pharo13/OCMethodNode.extension.st
@@ -1,21 +1,27 @@
-Extension { #name : 'RBMethodNode' }
+Extension { #name : 'OCMethodNode' }
 
-{ #category : '*RoelTyper' }
-RBMethodNode >> allOwnTempNames [
+{ #category : '*RoelTyper_Pharo13' }
+OCMethodNode >> allOwnTempNames [
 
 	^ self allOwnTempNamesByOwners flattened
 ]
 
-{ #category : '*RoelTyper' }
-RBMethodNode >> allOwnTempNamesByOwners [
+{ #category : '*RoelTyper_Pharo13' }
+OCMethodNode >> allOwnTempNamesByOwners [
 
 	^ ({ (self -> self ownTempNames) }
 	   , (self blockNodes collect: [ :each | each -> each ownTempNames ]))
 		  asOrderedDictionary
 ]
 
-{ #category : '*RoelTyper' }
-RBMethodNode >> ownTempNames [
+{ #category : '*RoelTyper_Pharo13' }
+OCMethodNode >> generateMethodByCompiler: aCompiler [
+
+	^ self generateMethod
+]
+
+{ #category : '*RoelTyper_Pharo13' }
+OCMethodNode >> ownTempNames [
 
 	| tempNames |
 	tempNames := self scope tempVarNames asOrderedCollection.

--- a/src/RoelTyper_Pharo13/RBMethodNode.extension.st
+++ b/src/RoelTyper_Pharo13/RBMethodNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'RBMethodNode' }
-
-{ #category : '*RoelTyper_Pharo13' }
-RBMethodNode >> generateMethodByCompiler: aCompiler [
-
-	^ self generateMethod
-]

--- a/src/RoelTyper_Pharo1_8-Tests/PharoEncoderV3InstvarInterfaceExtractorTest.class.st
+++ b/src/RoelTyper_Pharo1_8-Tests/PharoEncoderV3InstvarInterfaceExtractorTest.class.st
@@ -7,42 +7,131 @@ Class {
 }
 
 { #category : 'tests - message sends' }
-PharoEncoderV3InstvarInterfaceExtractorTest >> testNestedBlocksComplex [
+PharoEncoderV3InstvarInterfaceExtractorTest >> testInlinedBlocks [
+
 	| collector results |
 	collector := TypeCollector new.
 	results := collector
-		typeTmpsIn: ASampleClass >> #nestedBlocksComplex:
-		ofClass: ASampleClass.
+		           typeTmpsIn: ASampleClass >> #inlinedBlocks
+		           ofClass: ASampleClass.
 	self
 		assertCollection: results keys
 		hasSameElements:
-			#(#'^' #mArg #mTemp1 #mTemp2 #mTemp3 #'_block1->b1Arg' #'_block1->b1Temp' #'_block2->b2Temp1Shadowed' #'_block2->b2Temp2' #'_block3->b2b1Arg' #'_block3->b2b1Temp' #'_block3->b2Temp1Shadowed').
-	self assertCollection: (results at: #'^') assignments hasSameElements: {ASampleClass}.
-	self assertCollection: (results at: #mArg) assignments hasSameElements: {Array}.
-	self assertCollection: (results at: #mArg) interface hasSameElements: {#asArray}.
-	self assertCollection: (results at: #mTemp1) assignments hasSameElements: {SmallInteger}.
-	self assert: ((results at: #mTemp1) interface includesAll: {#lastDigit . #+}).
+			#( #'^' #t1 #t2 #t3 #'_block1->t4' #'_block1->t5' #'_block1->t6'
+			   #'_block2->t7' #'_block2->t8' #'_block4->t9' #'_block4->t10'
+			   #'_block4->t11' #'_block4->t12' ).
 	self
-		assertCollection: (results at: #mTemp2) interface
-		hasSameElements: {#primeFactors . #noMask:}.
-	self assertCollection: (results at: #mTemp3) assignments hasSameElements: {}.
-	self assertCollection: (results at: #mTemp3) interface hasSameElements: {#-}.
-	self assertCollection: (results at: #'_block1->b1Arg') assignments hasSameElements: {}.
+		assertCollection: (results at: #t1) assignments
+		hasSameElements: { SmallInteger }.
+	self
+		assertCollection: (results at: #t1) interface
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #t2) assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #t3) assignments
+		hasSameElements: { Array }.
+	self
+		assertCollection: (results at: #t3) interface
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block1->t4') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block1->t4') interface
+		hasSameElements: { #> }.
+	self
+		assertCollection: (results at: #'_block1->t5') assignments
+		hasSameElements: { ByteString }.
+	self
+		assertCollection: (results at: #'_block1->t5') interface
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block1->t6') assignments
+		hasSameElements: { SmallFloat64 }.
+	self
+		assertCollection: (results at: #'_block1->t6') interface
+		hasSameElements: { #* }.
+	self
+		assertCollection: (results at: #'_block2->t7') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block2->t8') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block4->t9') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block4->t10') assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #'_block4->t10') interface
+		includesAll: {  }.
+	self
+		assertCollection: (results at: #'_block4->t11') interface
+		includesAll: {  }.
+	self
+		assertCollection: (results at: #'_block4->t12') interface
+		includesAll: {  }
+]
+
+{ #category : 'tests - message sends' }
+PharoEncoderV3InstvarInterfaceExtractorTest >> testNestedBlocksComplex [
+
+	| collector results |
+	collector := TypeCollector new.
+	results := collector
+		           typeTmpsIn: ASampleClass >> #nestedBlocksComplex:
+		           ofClass: ASampleClass.
+	self
+		assertCollection: results keys
+		hasSameElements:
+			#( #'^' #mArg #mTemp1 #mTemp2 #mTemp3 #'_block1->b1Arg'
+			   #'_block1->b1Temp' #'_block2->b2Temp1Shadowed'
+			   #'_block2->b2Temp2' #'_block3->b2b1Arg' #'_block3->b2b1Temp'
+			   #'_block3->b2Temp1Shadowed' ).
+	self
+		assertCollection: (results at: #'^') assignments
+		hasSameElements: { ASampleClass }.
+	self
+		assertCollection: (results at: #mArg) assignments
+		hasSameElements: { Array }.
+	self
+		assertCollection: (results at: #mArg) interface
+		hasSameElements: { #asArray }.
+	self
+		assertCollection: (results at: #mTemp1) assignments
+		hasSameElements: { SmallInteger }.
+	self assert:
+		((results at: #mTemp1) interface includesAll: { #lastDigit.
+		 #+ }).
+	self
+		assertCollection: (results at: #mTemp3) assignments
+		hasSameElements: {  }.
+	self
+		assertCollection: (results at: #mTemp3) interface
+		hasSameElements: { #- }.
+	self
+		assertCollection: (results at: #'_block1->b1Arg') assignments
+		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block1->b1Arg') interface
-		hasSameElements: {#isInfix}.
+		hasSameElements: { #isInfix }.
 	self
 		assertCollection: (results at: #'_block1->b1Temp') interface
-		hasSameElements: {#capitalized}.
+		hasSameElements: { #capitalized }.
 	self
-		assertCollection: (results at: #'_block2->b2Temp1Shadowed') assignments
-		hasSameElements: {Character}.
+		assertCollection:
+		(results at: #'_block2->b2Temp1Shadowed') assignments
+		hasSameElements: { Character }.
 	self
-		assertCollection: (results at: #'_block2->b2Temp1Shadowed') interface
-		hasSameElements: {#digitValue}.
+		assertCollection:
+		(results at: #'_block2->b2Temp1Shadowed') interface
+		hasSameElements: { #digitValue }.
 	self
 		assertCollection: (results at: #'_block2->b2Temp2') interface
-		hasSameElements: {#value}.
+		hasSameElements: { #value }
 ]
 
 { #category : 'tests - message sends' }
@@ -56,10 +145,11 @@ PharoEncoderV3InstvarInterfaceExtractorTest >> testNestedBlocksUsingOuterTemps [
 	self
 		assertCollection: results keys
 		hasSameElements:
-		#( #'^' #t1 #tb1 #'_block1->t2' #'_block1->tb2' #'_block2->t3' ).
+			#( #'^' #ta1 #ta2 #ta3 #ta4 #'_block1->tb1' #'_block1->tb2'
+			   #'_block1->tb3' #'_block1->tb4' #'_block2->tc1' ).
 	self
 		assertCollection: (results at: #'^') assignments
-		hasSameElements: { ASampleClass }.
+		hasSameElements: { ASampleClass }
 ]
 
 { #category : 'tests - message sends' }
@@ -72,10 +162,11 @@ PharoEncoderV3InstvarInterfaceExtractorTest >> testNestedBlocksWithTemps [
 		           ofClass: ASampleClass.
 	self
 		assertCollection: results keys
-		hasSameElements: #( #'^' #t1 #'_block1->t2' #'_block1->t3' #'_block2->t4' ).
+		hasSameElements:
+		#( #'^' #t1 #'_block1->t2' #'_block1->t3' #'_block2->t4' ).
 	self
 		assertCollection: (results at: #'^') assignments
-		hasSameElements: { ASampleClass }.
+		hasSameElements: { ASampleClass }
 ]
 
 { #category : 'tests - message sends' }
@@ -88,7 +179,8 @@ PharoEncoderV3InstvarInterfaceExtractorTest >> testStreamContents [
 		           ofClass: ASampleClass.
 	self
 		assertCollection: results keys
-		hasSameElements: #( #'^' #array #string #'_block2->stream' #'_block3->each' ).
+		hasSameElements:
+		#( #'^' #array #string #'_block2->stream' #'_block3->each' ).
 	self
 		assertCollection: (results at: #'^') assignments
 		hasSameElements: { ASampleClass }.
@@ -97,7 +189,5 @@ PharoEncoderV3InstvarInterfaceExtractorTest >> testStreamContents [
 		hasSameElements: { #isEmpty. #do:separatedBy: }.
 	self
 		assertCollection: (results at: #string) interface
-		hasSameElements: {  }.
-		
-	
+		hasSameElements: {  }
 ]

--- a/src/RoelTyper_Pharo1_8-Tests/PharoEncoderV3InstvarInterfaceExtractorTest.class.st
+++ b/src/RoelTyper_Pharo1_8-Tests/PharoEncoderV3InstvarInterfaceExtractorTest.class.st
@@ -67,13 +67,13 @@ PharoEncoderV3InstvarInterfaceExtractorTest >> testInlinedBlocks [
 		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t10') interface
-		includesAll: {  }.
+		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t11') interface
-		includesAll: {  }.
+		hasSameElements: {  }.
 	self
 		assertCollection: (results at: #'_block4->t12') interface
-		includesAll: {  }
+		hasSameElements: {  }
 ]
 
 { #category : 'tests - message sends' }

--- a/src/RoelTyper_Pharo1_8/RBMethodNode.extension.st
+++ b/src/RoelTyper_Pharo1_8/RBMethodNode.extension.st
@@ -1,8 +1,33 @@
 Extension { #name : 'RBMethodNode' }
 
 { #category : '*RoelTyper_Pharo1_8' }
+RBMethodNode >> allOwnTempNames [
+
+	^ self allOwnTempNamesByOwners flattened
+]
+
+{ #category : '*RoelTyper_Pharo1_8' }
+RBMethodNode >> allOwnTempNamesByOwners [
+
+	^ ({ (self -> self ownTempNames) }
+	   , (self blockNodes collect: [ :each | each -> each ownTempNames ]))
+		  asOrderedDictionary
+]
+
+{ #category : '*RoelTyper_Pharo1_8' }
 RBMethodNode >> generateMethodByCompiler: aCompiler [
 
 	self compilationContext: aCompiler compilationContext.
 	^ self generate
+]
+
+{ #category : '*RoelTyper_Pharo1_8' }
+RBMethodNode >> ownTempNames [
+
+	| tempNames |
+	tempNames := self scope tempVarNames asOrderedCollection.
+	self scope tempVector
+		collect: [ :each | each name ]
+		thenDo: [ :each | tempNames addIfNotPresent: each ].
+	^ tempNames
 ]

--- a/src/RoelTyper_Pharo9_12/RBMethodNode.extension.st
+++ b/src/RoelTyper_Pharo9_12/RBMethodNode.extension.st
@@ -1,7 +1,32 @@
 Extension { #name : 'RBMethodNode' }
 
 { #category : '*RoelTyper_Pharo9_12' }
+RBMethodNode >> allOwnTempNames [
+
+	^ self allOwnTempNamesByOwners flattened
+]
+
+{ #category : '*RoelTyper_Pharo9_12' }
+RBMethodNode >> allOwnTempNamesByOwners [
+
+	^ ({ (self -> self ownTempNames) }
+	   , (self blockNodes collect: [ :each | each -> each ownTempNames ]))
+		  asOrderedDictionary
+]
+
+{ #category : '*RoelTyper_Pharo9_12' }
 RBMethodNode >> generateMethodByCompiler: aCompiler [
 
 	^ self generate
+]
+
+{ #category : '*RoelTyper_Pharo9_12' }
+RBMethodNode >> ownTempNames [
+
+	| tempNames |
+	tempNames := self scope tempVarNames asOrderedCollection.
+	self scope tempVector
+		collect: [ :each | each name ]
+		thenDo: [ :each | tempNames addIfNotPresent: each ].
+	^ tempNames
 ]


### PR DESCRIPTION
* More fixes for handling blocks in Pharo 9+ (Sista compiler), especially when dealing with temp vectors and inlined blocks.
* Adapting to most recent Pharo 13 changes.
* Added a few more tests.
* Minor code cleanup.
* Moved to GH Actions and set up testing in all versions of Pharo from 6.1 up to 13.